### PR TITLE
[MAR-28] Apply layout patterns to remaining pages

### DIFF
--- a/site/src/pages/articles.astro
+++ b/site/src/pages/articles.astro
@@ -17,8 +17,9 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   }
 
   .label {
-    font-size: 0.75rem;
-    letter-spacing: 0.3em;
-    color: var(--color-muted);
+    font-size: 1.2rem;
+    font-weight: 100;
+    letter-spacing: 0.2em;
+    color: var(--color-text);
   }
 </style>

--- a/site/src/pages/gear.astro
+++ b/site/src/pages/gear.astro
@@ -17,8 +17,9 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   }
 
   .label {
-    font-size: 0.75rem;
-    letter-spacing: 0.3em;
-    color: var(--color-muted);
+    font-size: 1.2rem;
+    font-weight: 100;
+    letter-spacing: 0.2em;
+    color: var(--color-text);
   }
 </style>

--- a/site/src/pages/hello.astro
+++ b/site/src/pages/hello.astro
@@ -57,9 +57,9 @@ const contactLinks = [
   }
 
   .heading {
-    font-size: clamp(1.5rem, 4vw, 2.5rem);
-    letter-spacing: 0.08em;
-    line-height: 1.1;
+    font-size: clamp(2rem, 5vw, 2.6rem);
+    letter-spacing: 0;
+    line-height: 1.4;
     color: var(--color-text);
   }
 
@@ -68,9 +68,10 @@ const contactLinks = [
   }
 
   .copy {
-    font-size: clamp(0.65rem, 1.5vw, 0.85rem);
-    letter-spacing: 0.08em;
-    color: var(--color-muted);
+    font-size: clamp(0.75rem, 1.5vw, 1.1rem);
+    letter-spacing: 0em;
+    font-weight: 100;
+    color: var(--color-text);
     line-height: 1.8;
   }
 
@@ -83,9 +84,10 @@ const contactLinks = [
   }
 
   .link {
-    font-size: 0.7rem;
-    letter-spacing: 0.2em;
-    color: var(--color-muted);
+    font-size: 1.2rem;
+    font-weight: 100;
+    letter-spacing: 0.05em;
+    color: var(--color-text);
     transition: color 0.2s;
   }
 

--- a/site/src/pages/projects.astro
+++ b/site/src/pages/projects.astro
@@ -84,15 +84,17 @@ const projects = [
   }
 
   .project-desc {
-    font-size: 0.75rem;
-    letter-spacing: 0.05em;
-    color: var(--color-muted);
-    line-height: 1.6;
+    font-size: clamp(0.75rem, 1.5vw, 1.1rem);
+    letter-spacing: 0em;
+    font-weight: 100;
+    color: var(--color-text);
+    line-height: 1.8;
   }
 
   .project-url {
-    font-size: 0.65rem;
-    letter-spacing: 0.1em;
+    font-size: 0.75rem;
+    font-weight: 100;
+    letter-spacing: 0.05em;
     color: var(--color-accent);
     opacity: 0.7;
     transition: opacity 0.2s;


### PR DESCRIPTION
## What

Applies the typography and color patterns from the manual "Layout fixes" commit to the four remaining pages that were not yet updated: `hello.astro`, `projects.astro`, `articles.astro`, and `gear.astro`.

## Changes per page

**`hello.astro`**
- `.heading`: `clamp(1.5rem → 2rem, 4vw → 5vw, 2.5rem → 2.6rem)`, `letter-spacing: 0.08em → 0`, `line-height: 1.1 → 1.4`
- `.copy`: larger font, `font-weight: 100`, `color: var(--color-text)` (was muted)
- `.link`: `0.7rem → 1.2rem`, `font-weight: 100`, `letter-spacing: 0.2em → 0.05em`, `color: var(--color-text)` (was muted)

**`projects.astro`**
- `.project-desc`: responsive clamp size, `font-weight: 100`, `color: var(--color-text)` (was muted), `line-height: 1.6 → 1.8`
- `.project-url`: `0.65rem → 0.75rem`, `font-weight: 100`, `letter-spacing: 0.1em → 0.05em`

**`articles.astro` / `gear.astro`** (stub pages)
- `.label`: `0.75rem → 1.2rem`, `font-weight: 100`, `letter-spacing: 0.3em → 0.2em`, `color: var(--color-text)` (was muted)

## Approach

Used `index.astro` and `about.astro` (both updated in the last commit) as the reference for all values. No structural or content changes — only CSS property alignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)