### PR TITLE
[MAR-32] Add more projects to the Projects section

### DIFF
--- a/site/src/pages/projects.astro
+++ b/site/src/pages/projects.astro
@@ -9,6 +9,20 @@ const projects = [
     url: 'https://repikue.com',
     urlLabel: 'repikue.com',
   },
+  {
+    monogram: 'C',
+    name: 'CoinsBucket',
+    description: 'Daily budget app that shows exactly how much you can spend today — self-correcting as your spending changes.',
+    url: 'https://coinsbucket.com',
+    urlLabel: 'coinsbucket.com',
+  },
+  {
+    monogram: 'F',
+    name: 'FeedBrix',
+    description: 'A beautiful feedback board to collect feature requests, bug reports, and support from your users.',
+    url: 'https://feedbrix.com',
+    urlLabel: 'feedbrix.com',
+  },
 ];
 ---
 


### PR DESCRIPTION
## What
Adds two more projects to the data-driven `projects` array in `site/src/pages/projects.astro`:

- **CoinsBucket** — coinsbucket.com — daily budget app
- **FeedBrix** — feedbrix.com — feedback-board SaaS

Both reuse the existing monogram card layout (`monogram`, `name`, `description`, `url`, `urlLabel`). The Projects page now shows **3 projects**.

## Why this approach
- The card style uses a **monogram letter in a bordered box**, not an image file. So "an image/thumbnail consistent with the existing card style" is satisfied by following the monogram pattern (`C`, `F`) — no new image assets were invented.
- Copy is drawn from each product's own live meta description, kept to one sentence to match the existing Repikue blurb.
- All links verified live (HTTP 200) and `npm run build` passes (4 pages built).

## Decision to flag for review
The issue treats **Repikue** and **CoinsBucket** as separate products, but they currently **serve the identical site** — `repikue.com` and `coinsbucket.com` return the same "CoinsBucket" page (repikue.com is the old domain). I left the existing **Repikue** card untouched because removing existing content is outside this issue's "add projects" scope, but you may want to **drop the Repikue card or repoint it** so the page doesn't show the same product twice. Happy to do that in a follow-up if you confirm.

## Acceptance criteria
- [x] Projects page shows 3+ projects using the existing card layout
- [x] All links work; monogram cards match the current visual style
- [x] `npm run build` passes

Closes MAR-32.