### PR TITLE
[MAR-42] Add share (OG/Twitter), canonical, Person JSON-LD, robots.txt + sitemap to the site

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -1,5 +1,9 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
+import sitemap from '@astrojs/sitemap';
 
 // https://astro.build/config
-export default defineConfig({});
+export default defineConfig({
+  site: 'https://vitormargis.com',
+  integrations: [sitemap()],
+});

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -8,6 +8,7 @@
       "name": "site",
       "version": "0.0.1",
       "dependencies": {
+        "@astrojs/sitemap": "^3.2.1",
         "astro": "^4.16.18"
       },
       "engines": {
@@ -62,6 +63,17 @@
       },
       "engines": {
         "node": "^18.17.1 || ^20.3.0 || >=21.0.0"
+      }
+    },
+    "node_modules/@astrojs/sitemap": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.2.1.tgz",
+      "integrity": "sha512-uxMfO8f7pALq0ADL6Lk68UV6dNYjJ2xGUzyjjVj60JLBs5a6smtlkBYv3tQ0DzoqwS7c9n4FUx5lgv0yPo/fgA==",
+      "license": "MIT",
+      "dependencies": {
+        "sitemap": "^8.0.0",
+        "stream-replace-string": "^2.0.0",
+        "zod": "^3.23.8"
       }
     },
     "node_modules/@astrojs/telemetry": {
@@ -1721,6 +1733,24 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/sax": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
+      "integrity": "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -1818,6 +1848,12 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -4745,6 +4781,15 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/sax": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+      "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
     "node_modules/section-matter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
@@ -4854,6 +4899,31 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
     },
+    "node_modules/sitemap": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-8.0.3.tgz",
+      "integrity": "sha512-9Ew1tR2WYw8RGE2XLy7GjkusvYXy8Rg6y8TYuBuQMfIEdGcWoJpY2Wr5DzsEiL/TKCw56+YKTCCUHglorEYK+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^17.0.5",
+        "@types/sax": "^1.2.1",
+        "arg": "^5.0.0",
+        "sax": "^1.4.1"
+      },
+      "bin": {
+        "sitemap": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=6.0.0"
+      }
+    },
+    "node_modules/sitemap/node_modules/@types/node": {
+      "version": "17.0.45",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
+      "license": "MIT"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4890,6 +4960,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/stream-replace-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
+      "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "7.2.0",
@@ -5031,6 +5107,26 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "license": "MIT"
     },
     "node_modules/unified": {
       "version": "11.0.5",

--- a/site/package.json
+++ b/site/package.json
@@ -12,6 +12,7 @@
     "astro": "astro"
   },
   "dependencies": {
+    "@astrojs/sitemap": "^3.2.1",
     "astro": "^4.16.18"
   }
 }

--- a/site/public/robots.txt
+++ b/site/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://vitormargis.com/sitemap-index.xml

--- a/site/src/layouts/BaseLayout.astro
+++ b/site/src/layouts/BaseLayout.astro
@@ -9,6 +9,10 @@ interface Props {
 const { title = 'Vitor Margis', description = 'Software Engineer & Engineering Manager' } = Astro.props;
 const currentPath = Astro.url.pathname;
 
+const pageTitle = title === 'Vitor Margis' ? title : `${title} — Vitor Margis`;
+const canonicalURL = new URL(Astro.url.pathname, Astro.site);
+const ogImageURL = new URL('/og.png', Astro.site);
+
 const navLinks = [
   { href: '/about', label: 'ABOUT' },
   { href: '/projects', label: 'PROJECTS' },
@@ -21,6 +25,28 @@ const socialLinks = [
   { href: 'https://twitter.com/vitormargis', label: 'TWITTER' },
   { href: 'https://adplist.org/mentors/vitor-margis', label: 'ADPList' },
 ];
+
+// Social profiles for the Person JSON-LD `sameAs` — inlined from the links
+// already present across the site (nav socials + hello page contacts).
+// MAR-33 will later DRY these into a single source of truth.
+const sameAs = [
+  'https://github.com/vitormargis',
+  'https://linkedin.com/in/vitormargis',
+  'https://twitter.com/vitormargis',
+  'https://youtube.com/@vitormargis',
+  'https://instagram.com/vitormargis',
+  'https://adplist.org/mentors/vitor-margis',
+];
+
+const personSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'Person',
+  name: 'Vitor Margis',
+  jobTitle: 'Engineering Manager @ Angi',
+  url: new URL('/', Astro.site).href,
+  image: new URL('/hero1.png', Astro.site).href,
+  sameAs,
+};
 ---
 
 <!doctype html>
@@ -30,11 +56,29 @@ const socialLinks = [
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="generator" content={Astro.generator} />
     <meta name="description" content={description} />
+    <link rel="canonical" href={canonicalURL} />
+
+    <!-- Open Graph -->
+    <meta property="og:title" content={pageTitle} />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content={canonicalURL} />
+    <meta property="og:description" content={description} />
+    <meta property="og:image" content={ogImageURL} />
+    <meta property="og:site_name" content="Vitor Margis" />
+
+    <!-- Twitter/X -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content={pageTitle} />
+    <meta name="twitter:description" content={description} />
+    <meta name="twitter:image" content={ogImageURL} />
+    <meta name="twitter:creator" content="@vitormargis" />
+
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Josefin+Sans:ital,wght@0,100..700;1,100..700&family=Poppins:wght@100;200;300;400;500;600&display=swap" rel="stylesheet" />
     <link rel="icon" href="/favicon.ico" />
-    <title>{title === 'Vitor Margis' ? title : `${title} — Vitor Margis`}</title>
+    <title>{pageTitle}</title>
+    <script type="application/ld+json" set:html={JSON.stringify(personSchema)} />
   </head>
   <body>
     <div class="shell">


### PR DESCRIPTION
Closes MAR-42.

## What changed
Adds share/discovery metadata to the site, all in `BaseLayout.astro` + `astro.config.mjs` + `public/`.

- **`astro.config.mjs`** — set `site: 'https://vitormargis.com'` (required for absolute OG/canonical URLs) and register `@astrojs/sitemap`.
- **`BaseLayout.astro` `<head>`** — derived from the existing `title`/`description` props + `Astro.site`:
  - Open Graph: `og:title`, `og:type=website`, `og:url` (absolute, per-page), `og:description`, `og:image` → absolute `/og.png`, `og:site_name`.
  - Twitter/X: `twitter:card=summary_large_image`, `twitter:title`, `twitter:description`, `twitter:image`, `twitter:creator=@vitormargis`.
  - `<link rel="canonical">` — absolute, per-page.
  - Site-wide `Person` JSON-LD with `name`, `jobTitle` (Engineering Manager @ Angi), `url`, `image`, and `sameAs` = the six social URLs already in the codebase (GitHub, LinkedIn, X, YouTube, Instagram, ADPList).
- **`public/robots.txt`** — allow-all + sitemap reference.

## Decisions
- **Domain**: used `https://vitormargis.com` — the domain the issue's problem statement is written around (MAR-18). Per the issue, shipping with the intended `site` value even if DNS isn't live yet.
- **`@astrojs/sitemap` pinned to `3.2.1`**: the latest `3.7.x` relies on the `astro:routes:resolved` hook that only exists in Astro 5, so it crashed the build (`_routes.reduce` of undefined) on this Astro 4.16 site. `3.2.1` reads `routes` from `astro:build:done` and works on Astro 4.
- **Social URLs inlined** (not DRY'd against the nav) as the issue instructs — the single-source-of-truth refactor is MAR-33.
- `og.png` doesn't exist yet (delivered by sibling designer task MAR-43); referencing the absolute `/og.png` URL now is intended and correct.

## Verification
`npm run build` passes. Confirmed in the built output:
- Home `<head>` has all OG + Twitter tags, `canonical=https://vitormargis.com/`, and the `Person` JSON-LD with a 6-entry `sameAs`.
- Sub-page (`/about/`) canonical + `og:url` are correctly per-page (`https://vitormargis.com/about/`).
- `dist/robots.txt` served; `dist/sitemap-index.xml` + `dist/sitemap-0.xml` generated with all 4 pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)