### PR TITLE
[MAR-33] Single source of truth for social links

### DIFF
--- a/site/src/data/social.ts
+++ b/site/src/data/social.ts
@@ -1,0 +1,17 @@
+// Single source of truth for social profiles and contact info.
+// Consumed by the layout social rail, the hello contact page, and the
+// Person JSON-LD `sameAs`, so the sets can no longer diverge.
+export const socialLinks = [
+  { href: 'https://github.com/vitormargis', label: 'GITHUB' },
+  { href: 'https://linkedin.com/in/vitormargis', label: 'LINKEDIN' },
+  { href: 'https://twitter.com/vitormargis', label: 'TWITTER' },
+  { href: 'https://youtube.com/@vitormargis', label: 'YOUTUBE' },
+  { href: 'https://instagram.com/vitormargis', label: 'INSTAGRAM' },
+  { href: 'https://adplist.org/mentors/vitor-margis', label: 'ADPLIST' },
+];
+
+// Email is a contact method, not a social profile — only the contact page uses it.
+export const email = { href: 'mailto:vitor@margis.com.br', label: 'EMAIL' };
+
+// Profile URLs for the Person JSON-LD `sameAs`.
+export const sameAs = socialLinks.map(({ href }) => href);

--- a/site/src/layouts/BaseLayout.astro
+++ b/site/src/layouts/BaseLayout.astro
@@ -1,5 +1,6 @@
 ---
 import '../styles/global.css';
+import { socialLinks, sameAs } from '../data/social';
 
 interface Props {
   title?: string;
@@ -17,25 +18,6 @@ const navLinks = [
   { href: '/about', label: 'ABOUT' },
   { href: '/projects', label: 'PROJECTS' },
   { href: '/hello', label: 'HELLO' },
-];
-
-const socialLinks = [
-  { href: 'https://github.com/vitormargis', label: 'GITHUB' },
-  { href: 'https://linkedin.com/in/vitormargis', label: 'LINKEDIN' },
-  { href: 'https://twitter.com/vitormargis', label: 'TWITTER' },
-  { href: 'https://adplist.org/mentors/vitor-margis', label: 'ADPList' },
-];
-
-// Social profiles for the Person JSON-LD `sameAs` — inlined from the links
-// already present across the site (nav socials + hello page contacts).
-// MAR-33 will later DRY these into a single source of truth.
-const sameAs = [
-  'https://github.com/vitormargis',
-  'https://linkedin.com/in/vitormargis',
-  'https://twitter.com/vitormargis',
-  'https://youtube.com/@vitormargis',
-  'https://instagram.com/vitormargis',
-  'https://adplist.org/mentors/vitor-margis',
 ];
 
 const personSchema = {

--- a/site/src/pages/hello.astro
+++ b/site/src/pages/hello.astro
@@ -1,16 +1,8 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
+import { socialLinks, email } from '../data/social';
 
-// TODO: confirm Twitter/X handle is still active and whether to add Bluesky before launch
-// TODO: confirm whether "available for work" copy should appear (was on old Hexo site)
-const contactLinks = [
-  { href: 'mailto:vitor@margis.com.br', label: 'EMAIL' },
-  { href: 'https://github.com/vitormargis', label: 'GITHUB' },
-  { href: 'https://linkedin.com/in/vitormargis', label: 'LINKEDIN' },
-  { href: 'https://youtube.com/@vitormargis', label: 'YOUTUBE' },
-  { href: 'https://instagram.com/vitormargis', label: 'INSTAGRAM' },
-  { href: 'https://adplist.org/mentors/vitor-margis', label: 'ADPLIST' },
-];
+const contactLinks = [email, ...socialLinks];
 ---
 
 <BaseLayout title="Hello" description="Get in touch with Vitor Margis">


### PR DESCRIPTION
## What & why

Social profiles were defined in **three** places that disagreed:

- Layout social rail (`BaseLayout.astro`): GitHub / LinkedIn / **Twitter** / ADPList
- Contact page (`hello.astro`): Email / GitHub / LinkedIn / **YouTube** / **Instagram** / ADPList
- Person JSON-LD `sameAs` (`BaseLayout.astro`): the full union of the above

The rail and contact page diverged (Twitter vs YouTube/Instagram), which is the bug MAR-33 describes.

## Change

New `site/src/data/social.ts` is the single source of truth; all three consumers now read from it:

- `socialLinks` — canonical social profiles (the full union already committed to `sameAs`). The rail and contact page now render the **same** set, so they can no longer diverge. The rail gains YouTube + Instagram as a result.
- `email` — a contact method, not a social profile, so it lives separately and is used only by the hello page.
- `sameAs` — derived from `socialLinks` for the JSON-LD (no more hand-maintained duplicate).

## Decisions (the two leftover TODOs in `hello.astro`)

- **Twitter/X** — kept. It was already live in the rail and `sameAs`; there's no evidence the handle is inactive, so removing it would be the riskier change. Status quo retained.
- **Bluesky** — not added. No Bluesky handle is referenced anywhere in the codebase, so there's nothing to link to without inventing one.
- **"available for work" copy** — not re-added. The existing hello copy already conveys openness to work/collaboration; re-adding specific copy is a content decision out of scope for this DRY task.

Labels were normalized to all-caps (`ADPList` → `ADPLIST` in the rail) so a single source can serve both locations consistently, matching every sibling label.

## Verification

- `tsc --noEmit` passes.
- Full `astro build` intentionally not run locally (memory-constrained shared box); the Vercel preview / CI is the authoritative build check. Changes are import-only refactors of existing data, no logic changes.

Closes MAR-33.
