### PR TITLE
[MAR-61] Fix three WCAG accessibility failures on vitormargis.com (alt text, carousel, contrast)

### DIFF
--- a/site/src/layouts/BaseLayout.astro
+++ b/site/src/layouts/BaseLayout.astro
@@ -85,7 +85,7 @@ const personSchema = {
       <!-- Top bar — visible only on mobile -->
       <header class="topbar">
         <a href="/" class="logo-link" aria-label="Home">
-          <img src="/logo.png" alt="Vitor Margis" class="logo" />
+          <img src="/logo.png" alt="Vitor Margis — home" class="logo" />
         </a>
         <span class="wordmark"><span class="wordmark-first">VITOR</span><span class="wordmark-last">MARGIS</span></span>
       </header>
@@ -93,7 +93,7 @@ const personSchema = {
       <!-- Left vertical nav -->
       <nav class="sidenav" aria-label="Main navigation">
         <a href="/" class="logo-link" aria-label="Home">
-          <img src="/logo.png" alt="Vitor Margis" class="logo" />
+          <img src="/logo.png" alt="Vitor Margis — home" class="logo" />
         </a>
         {navLinks.map(({ href, label }) => (
           <a

--- a/site/src/pages/about.astro
+++ b/site/src/pages/about.astro
@@ -26,18 +26,18 @@ import BaseLayout from '../layouts/BaseLayout.astro';
             <p>Back in 2010 I got a degree on Graphic Design and worked at a couple of small design studios, mainly as do-all web guy. Until 2014, when I decided to pivot my career and focus only on web development.</p>
             <p>
               Since then I had the opportunity to work, as part of <a href="https://www.vizir.com.br" target="_blank" rel="noopener noreferrer">Vizir Software Studio</a>,{' '} team, on several start-up projects as well as big projects for big companies like: Sprinklr, Grupo Abril, Natura and Edenred, just to name some. 
-              <span class="logo-badge vizir"><img src="/about-vizir.png" class="" alt="Vitor Margis" /></span>
+              <span class="logo-badge vizir"><img src="/about-vizir.png" class="" alt="" /></span>
             </p>
             <p>
-              <span class="logo-badge travix"><img src="/about-travix.png" class="" alt="Vitor Margis" /></span>
+              <span class="logo-badge travix"><img src="/about-travix.png" class="" alt="" /></span>
               I then moved to the Netherlands to work at <a href="https://www.travix.com" target="_blank" rel="noopener noreferrer">Travix International</a>,{' '}a global leading plane ticket sellers, which, with its 5 brands (CheapTickets, BudgetAir, Vayama, FlugLaden and VliegWinkel), is present in 39 countries. There I worked as front-end Engineer and subsequently as a Manager, and was responsible for building the new front-end platform from the ground up with a incredible global team, using some of the coolest technologies out there.
             </p>
             <p>
               I then joined <a href="https://www.sesame.hr" target="_blank" rel="noopener noreferrer">Sesame Care</a>,{' '}working as an Engineering Manager helping bring affordable health care to people.
-              <span class="logo-badge sesame"><img src="/about-sesame.png" class="" alt="Vitor Margis" /></span>
+              <span class="logo-badge sesame"><img src="/about-sesame.png" class="" alt="" /></span>
             </p>
             <p>
-              <span class="logo-badge instapro"><img src="/about-angi.png" class="" alt="Vitor Margis" /></span>
+              <span class="logo-badge instapro"><img src="/about-angi.png" class="" alt="" /></span>
               Currently I hold a position at <a href="https://www.angi.com" target="_blank" rel="noopener noreferrer">Angi</a>,{' '}working as an Engineering Manager.
             </p>
             <p>Anyway, if you got all the way down here, the odds are you want to get in touch, for a job, for hiring or just to talk. Feel free to reach out on any of my social medias or just drop by a message here            </p>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -7,10 +7,10 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     <div class="hero-inner">
       <div class="photo-wrap">
         <div class="carousel-slides">
-          <img src="/hero1.png" class="carousel-slide active" alt="Vitor Margis" width="250" height="250" />
-          <img src="/hero2.png" class="carousel-slide" alt="Vitor Margis" width="250" height="250" />
-          <img src="/hero3.png" class="carousel-slide" alt="Vitor Margis" width="250" height="250" />
-          <img src="/hero4.png" class="carousel-slide" alt="Vitor Margis" width="250" height="250" />
+          <img src="/hero1.png" class="carousel-slide active" alt="Vitor Margis" aria-hidden="false" width="250" height="250" />
+          <img src="/hero2.png" class="carousel-slide" alt="" aria-hidden="true" width="250" height="250" />
+          <img src="/hero3.png" class="carousel-slide" alt="" aria-hidden="true" width="250" height="250" />
+          <img src="/hero4.png" class="carousel-slide" alt="" aria-hidden="true" width="250" height="250" />
         </div>
       </div>
 
@@ -111,7 +111,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     font-size: clamp(0.75rem, 1.5vw, 1.2rem);
     letter-spacing: 0.2em;
     font-weight: 200;
-    color: #555555;
+    color: var(--color-muted);
     font-variant: small-caps;
     margin-top: 1rem;
   }
@@ -151,9 +151,13 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 
   function go(n: number) {
     slides[current].classList.remove('active');
+    slides[current].setAttribute('aria-hidden', 'true');
     current = (n + slides.length) % slides.length;
     slides[current].classList.add('active');
+    slides[current].setAttribute('aria-hidden', 'false');
   }
 
-  setInterval(() => go(current + 1), 4000);
+  if (!window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+    setInterval(() => go(current + 1), 4000);
+  }
 </script>


### PR DESCRIPTION
## What & why

Fixes three concrete WCAG failures found in the accessibility audit of the live site (MAR-61). All are front-end-only, high-confidence fixes.

### Fix 1 — Misleading/duplicate `alt` text (WCAG 1.1.1, Level A)
Every image previously shipped `alt="Vitor Margis"`, so screen readers announced logos and duplicate hero photos all as "Vitor Margis".
- `index.astro`: the active hero photo keeps a meaningful `alt="Vitor Margis"`; the three duplicate hero photos are now decorative (`alt=""`).
- `about.astro`: the four company logos are decorative (`alt=""`) — each company name already appears as adjacent link text in the same paragraph, so a descriptive alt would be redundant. This follows the issue's stated preference ("prefer `alt=""` if the name is already announced").
- `BaseLayout.astro`: the site logo (appears ×2) gets one meaningful `alt="Vitor Margis — home"`.

### Fix 2 — Auto-advancing carousel (WCAG 2.2.2, Level A)
- The 4s auto-advance interval now only starts when the user has **not** requested `prefers-reduced-motion: reduce`.
- Slides toggle `aria-hidden` so assistive tech is only exposed to the active slide (active `false`, inactive `true`).
- I did **not** add a visible pause/play control — it's marked optional in the issue and the reduced-motion guard alone satisfies 2.2.2. Kept scope tight.

### Fix 3 — Tagline colour contrast (WCAG 1.4.3, Level AA)
- Lifted the tagline from `#555555` (2.4:1) to `var(--color-muted)` = `#888888` (~5:1 on `#171717`). Reused the existing muted design token that the social links already use, rather than hardcoding a new hex, for consistency.

## Verification
No test runner exists in this repo (static Astro site) and the only JS is trivial DOM toggling, so no unit tests were added. Changes use standard, type-safe DOM APIs. I did not run a full production build (memory-bounded box) — leaving the authoritative build to CI / the Vercel preview.

Closes MAR-61.